### PR TITLE
Potential fix for code scanning alert no. 4: Storage of sensitive information in build artifact

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,9 @@ module.exports = {
   plugins: [
     new Dotenv(), // Loads variables from .env file
     new webpack.DefinePlugin({
-      "process.env": JSON.stringify(process.env), // Inject process.env globally
+      "process.env": JSON.stringify({
+        DEBUG: process.env.DEBUG, // Add other safe environment variables here
+      }), // Inject selected environment variables globally
     }),
   ],
   resolve: {


### PR DESCRIPTION
Potential fix for [https://github.com/Mykal-Steele/mykal-steele.github.io/security/code-scanning/4](https://github.com/Mykal-Steele/mykal-steele.github.io/security/code-scanning/4)

To fix the problem, we need to ensure that only the environment variables meant to be publicly available are included in the build artifact. Instead of injecting all environment variables, we should explicitly specify which variables are safe to include. This can be done by creating an object with only the necessary environment variables and passing that object to `webpack.DefinePlugin`.

1. Identify the environment variables that are safe to include in the build artifact.
2. Modify the `webpack.config.js` file to create an object with only the selected environment variables.
3. Pass this object to `webpack.DefinePlugin` instead of `process.env`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
