### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-router-dom": "^7.1.3",
     "socket.io-client": "^4.8.1",
     "terser": "^5.39.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "dompurify": "^3.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.26.9",

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -11,7 +11,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import SkeletonLoader from "../Components/SkeletonLoader";
 import useInfiniteScroll from "../hooks/useInfiniteScroll";
 import useClickOutside from "../hooks/useClickOutside";
-
+import DOMPurify from "dompurify";
 const Home = () => {
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -81,7 +81,9 @@ const Home = () => {
       const validImageTypes = ["image/jpeg", "image/png"];
       if (validImageTypes.includes(file.type)) {
         setImage(file);
-        setImagePreview(URL.createObjectURL(file));
+        const objectUrl = URL.createObjectURL(file);
+        const sanitizedUrl = DOMPurify.sanitize(objectUrl);
+        setImagePreview(sanitizedUrl);
       } else {
         setError({
           message: "Invalid file type. Please upload an image (JPEG or PNG).",


### PR DESCRIPTION
Potential fix for [https://github.com/Mykal-Steele/Adorio/security/code-scanning/3](https://github.com/Mykal-Steele/Adorio/security/code-scanning/3)

To fix the problem, we need to ensure that the `imagePreview` URL is safe and cannot be exploited for XSS attacks. One way to achieve this is by validating the file type and ensuring it is a legitimate image file before setting the `imagePreview` state. Additionally, we can use a library like `DOMPurify` to sanitize the URL if necessary.

1. Validate the file type to ensure it is a legitimate image file.
2. Use `DOMPurify` to sanitize the `imagePreview` URL before setting it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
