### PR TITLE
 fix(ci): clear puppeteer cache before browser install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: npm run setup
       - name: Install Puppeteer browser
-        run: npx puppeteer browsers install chrome
+        run: rm -rf ~/.cache/puppeteer && npx puppeteer browsers install chrome
       - name: Create .env.production
         run: |
           echo "NODE_ENV=production" >> .env.production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: npm run setup
       - name: Install Puppeteer browser
-        run: node node_modules/.bin/puppeteer browsers install chrome
+        run: rm -rf ~/.cache/puppeteer && node node_modules/.bin/puppeteer browsers install chrome
       - name: Create .env.production
         run: |
           echo "NODE_ENV=production" >> .env.production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: npm run setup
       - name: Install Puppeteer browser
-        run: rm -rf ~/.cache/puppeteer && npx puppeteer browsers install chrome
+        run: node node_modules/.bin/puppeteer browsers install chrome
       - name: Create .env.production
         run: |
           echo "NODE_ENV=production" >> .env.production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,17 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm run setup
-      - name: Install Puppeteer browser
-        run: rm -rf ~/.cache/puppeteer && node node_modules/.bin/puppeteer browsers install chrome
+      - name: Set Puppeteer Chrome path
+        run: |
+          CHROME=$(which google-chrome-stable 2>/dev/null || which google-chrome 2>/dev/null || which chromium-browser 2>/dev/null || which chromium 2>/dev/null || echo "")
+          if [ -n "$CHROME" ]; then
+            echo "Using system Chrome: $CHROME"
+            echo "PUPPETEER_EXECUTABLE_PATH=$CHROME" >> $GITHUB_ENV
+          else
+            echo "System Chrome not found, installing via puppeteer"
+            rm -rf ~/.cache/puppeteer
+            node node_modules/.bin/puppeteer browsers install chrome
+          fi
       - name: Create .env.production
         run: |
           echo "NODE_ENV=production" >> .env.production

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+node node_modules/lint-staged/bin/lint-staged.js


### PR DESCRIPTION
## Summary

- Puppeteer postinstall (triggered by `npm run setup`) creates the browser
  folder but leaves the binary missing when the download fails
- The subsequent `browsers install` step finds the folder, assumes it's
  already installed, and exits â causing the `executable is missing` error
- Fix: `rm -rf ~/.cache/puppeteer` before install to force a clean download
- Also fixes the husky pre-commit hook broken on Windows
  (`npx lint-staged` â `node node_modules/lint-staged/bin/lint-staged.js`)

## Test plan

- [ ] CI integration tests pass on next push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI integration-test setup to install the required browser components using the locally installed Puppeteer tooling.
  * Adjusted the pre-commit hook to run staged linting via the local installed tooling rather than using on-demand execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->