### PR TITLE
fix(ui): polish navbar, 404 page, one-dark default, social and hosting UX

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -9,7 +9,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider
       attribute="data-theme"
-      defaultTheme="midnight"
+      defaultTheme="one-dark"
       themes={['midnight', 'nord', 'dracula', 'one-dark', 'catppuccin']}
       disableTransitionOnChange
       enableSystem={false}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -27,108 +27,136 @@ const Navbar = () => {
       transition={{ type: 'spring', stiffness: 300, damping: 20 }}
       className="sticky top-0 z-50 bg-gray-950/95 backdrop-blur-lg border-b border-gray-800/100 shadow-2xl"
     >
-      <div className="container mx-auto px-2 sm:px-4">
-        <div className="flex items-center justify-between h-14 sm:h-16 relative">
-          <Link href="/" className="flex items-center space-x-1 sm:space-x-2 group ml-1">
+      <div className="container mx-auto px-4">
+        {/* Desktop: three-column layout so nav links are truly centered */}
+        <div className="hidden sm:flex items-center h-16 relative">
+          <Link href="/" className="flex items-center space-x-2 group">
             <motion.div whileHover={{ rotate: 15 }} whileTap={{ scale: 0.95 }}>
-              <SparklesIcon className="h-6 w-6 sm:h-7 sm:w-7 text-purple-400 transition-transform" />
+              <SparklesIcon className="h-7 w-7 text-purple-400" />
             </motion.div>
-            <span className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+            <span className="text-2xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
               Adorio
             </span>
           </Link>
 
-          <div className="flex items-center gap-2 sm:gap-4">
-            <div className="hidden sm:flex items-center gap-2 mr-1">
-              {token ? (
-                <>
-                  <NavLink href="/social" text="Social" />
-                  <NavLink href="/profile" text="Profile" />
-                  <NavLink href="/coding" text="Coding" />
-                  <NavLink href="/smartcity" text="SmartCity" />
-                  <NavLink href="/rygame" text="RyGame" />
-                  <NavLink href="/cao" text="CAO" external />
-                  <NavLink href="/algo" text="Algorithms" />
-                </>
-              ) : (
-                <>
-                  <NavLink href="/coding" text="Coding" />
-                  <NavLink href="/smartcity" text="SmartCity" />
-                  <NavLink href="/cao" text="CAO" external />
-                  <NavLink href="/algo" text="Algorithms" />
-                </>
-              )}
-            </div>
-
+          <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-1">
             {token ? (
-              <div className="flex items-center gap-2 sm:gap-4">
-                <motion.button
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
-                  className="px-3 py-1.5 sm:px-6 sm:py-3 text-sm sm:text-base rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg hover:shadow-xl transition-all relative overflow-hidden group flex items-center justify-center"
-                  onClick={handleLogout}
-                >
-                  <span className="relative z-10">Logout</span>
-                  <div className="absolute inset-0 bg-gradient-to-r from-white/15 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
-                </motion.button>
-              </div>
+              <>
+                <NavLink href="/social" text="Social" />
+                <NavLink href="/profile" text="Profile" />
+                <NavLink href="/hosting" text="Hosting" />
+                <NavLink href="/coding" text="Coding" />
+                <NavLink href="/smartcity" text="SmartCity" />
+                <NavLink href="/rygame" text="RyGame" />
+                <NavLink href="/cao" text="CAO" external />
+              </>
             ) : (
-              <div className="flex items-center gap-2 sm:gap-4">
-                <NavLink href="/login" text="Login" className="hidden sm:block" />
-                <motion.button
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
-                  className="px-3 py-1.5 sm:px-6 sm:py-3 text-sm sm:text-base rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg hover:shadow-xl transition-all relative overflow-hidden group flex items-center justify-center"
-                >
-                  <Link href="/register" className="relative z-10">
-                    Get Started
+              <>
+                <NavLink href="/coding" text="Coding" />
+                <NavLink href="/smartcity" text="SmartCity" />
+                <NavLink href="/cao" text="CAO" external />
+              </>
+            )}
+          </div>
+
+          <div className="ml-auto">
+            {token ? (
+              <motion.button
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                className="px-5 py-2.5 text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg hover:shadow-xl transition-all relative overflow-hidden group"
+                onClick={handleLogout}
+              >
+                <span className="relative z-10">Logout</span>
+                <div className="absolute inset-0 bg-gradient-to-r from-white/15 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
+              </motion.button>
+            ) : (
+              <div className="flex items-center gap-3">
+                <NavLink href="/login" text="Login" />
+                <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                  <Link
+                    href="/register"
+                    className="px-5 py-2.5 text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg hover:shadow-xl transition-all relative overflow-hidden group flex items-center"
+                  >
+                    <span className="relative z-10">Get Started</span>
+                    <div className="absolute inset-0 bg-gradient-to-r from-white/15 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
                   </Link>
-                  <div className="absolute inset-0 bg-gradient-to-r from-white/15 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
-                </motion.button>
+                </motion.div>
               </div>
             )}
           </div>
         </div>
 
-        <div className="sm:hidden flex justify-center space-x-4 pb-2">
-          {token ? (
-            <>
-              <NavLink href="/social" text="Social" />
-              <NavLink href="/profile" text="Profile" />
-              <NavLink href="/coding" text="Coding" />
-              <NavLink href="/smartcity" text="SmartCity" />
-              <NavLink href="/rygame" text="RyGame" />
-              <NavLink href="/cao" text="CAO" external />
-            </>
-          ) : (
-            <>
-              <NavLink href="/coding" text="Coding" />
-              <NavLink href="/smartcity" text="SmartCity" />
-              <NavLink href="/cao" text="CAO" external />
-              <NavLink href="/login" text="Login" />
-              <NavLink href="/register" text="Register" />
-            </>
-          )}
+        {/* Mobile: logo + button row, then scrollable nav below */}
+        <div className="sm:hidden">
+          <div className="flex items-center justify-between h-14">
+            <Link href="/" className="flex items-center space-x-1.5 group">
+              <motion.div whileHover={{ rotate: 15 }} whileTap={{ scale: 0.95 }}>
+                <SparklesIcon className="h-6 w-6 text-purple-400" />
+              </motion.div>
+              <span className="text-xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+                Adorio
+              </span>
+            </Link>
+
+            {token ? (
+              <motion.button
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                className="px-3 py-1.5 text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white"
+                onClick={handleLogout}
+              >
+                Logout
+              </motion.button>
+            ) : (
+              <Link
+                href="/register"
+                className="px-3 py-1.5 text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white"
+              >
+                Get Started
+              </Link>
+            )}
+          </div>
+
+          <div className="flex overflow-x-auto gap-1 pb-2 scrollbar-none">
+            {token ? (
+              <>
+                <NavLink href="/social" text="Social" />
+                <NavLink href="/profile" text="Profile" />
+                <NavLink href="/hosting" text="Hosting" />
+                <NavLink href="/coding" text="Coding" />
+                <NavLink href="/smartcity" text="SmartCity" />
+                <NavLink href="/rygame" text="RyGame" />
+                <NavLink href="/cao" text="CAO" external />
+              </>
+            ) : (
+              <>
+                <NavLink href="/coding" text="Coding" />
+                <NavLink href="/smartcity" text="SmartCity" />
+                <NavLink href="/cao" text="CAO" external />
+                <NavLink href="/login" text="Login" />
+              </>
+            )}
+          </div>
         </div>
       </div>
     </motion.nav>
   );
 };
 
-/** @param {{ href: string, text: string, className?: string, external?: boolean }} props */
 const NavLink = ({ href, text, className = '', external = false }) => (
-  <motion.div whileHover={{ scale: 1.05 }} className={`relative ${className}`}>
+  <motion.div whileHover={{ scale: 1.05 }} className={`relative shrink-0 ${className}`}>
     {external ? (
       <a
         href={href}
-        className="text-gray-300 px-3 py-1 sm:px-4 sm:py-2 text-sm sm:text-base font-medium hover:text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-blue-400 transition-all duration-300 flex items-center"
+        className="text-gray-300 px-3 py-2 text-sm font-medium hover:text-white transition-colors duration-200 flex items-center rounded-lg hover:bg-white/5"
       >
         {text}
       </a>
     ) : (
       <Link
         href={href}
-        className="text-gray-300 px-3 py-1 sm:px-4 sm:py-2 text-sm sm:text-base font-medium hover:text-transparent bg-clip-text bg-gradient-to-r from-purple-400 to-blue-400 transition-all duration-300 flex items-center"
+        className="text-gray-300 px-3 py-2 text-sm font-medium hover:text-white transition-colors duration-200 flex items-center rounded-lg hover:bg-white/5"
       >
         {text}
       </Link>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,21 +25,23 @@ const Navbar = () => {
       initial={{ y: -100 }}
       animate={{ y: 0 }}
       transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-      className="sticky top-0 z-50 bg-gray-950/95 backdrop-blur-lg border-b border-gray-800/100 shadow-2xl"
+      className="sticky top-0 z-50 bg-gray-950/95 backdrop-blur-lg border-b border-gray-800 shadow-lg"
     >
-      <div className="container mx-auto px-4">
-        {/* Desktop: three-column layout so nav links are truly centered */}
-        <div className="hidden sm:flex items-center h-16 relative">
-          <Link href="/" className="flex items-center space-x-2 group">
-            <motion.div whileHover={{ rotate: 15 }} whileTap={{ scale: 0.95 }}>
-              <SparklesIcon className="h-7 w-7 text-purple-400" />
+      <div className="container mx-auto px-3 sm:px-4">
+        {/* Single row at every viewport: [logo] [nav fills middle] [button] */}
+        <div className="flex items-center h-14 sm:h-16 gap-2 relative">
+          {/* Logo — always left, never shrinks */}
+          <Link href="/" className="flex items-center gap-1.5 shrink-0 group">
+            <motion.div whileHover={{ rotate: 15 }} whileTap={{ scale: 0.9 }}>
+              <SparklesIcon className="h-5 w-5 sm:h-6 sm:w-6 text-purple-400" />
             </motion.div>
-            <span className="text-2xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+            <span className="text-lg sm:text-xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
               Adorio
             </span>
           </Link>
 
-          <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-1">
+          {/* Desktop nav — absolutely centered so it doesn't shift with logo/button widths */}
+          <div className="absolute left-1/2 -translate-x-1/2 hidden sm:flex items-center gap-0.5">
             {token ? (
               <>
                 <NavLink href="/social" text="Social" />
@@ -55,87 +57,53 @@ const Navbar = () => {
                 <NavLink href="/coding" text="Coding" />
                 <NavLink href="/smartcity" text="SmartCity" />
                 <NavLink href="/cao" text="CAO" external />
+                <NavLink href="/login" text="Login" />
               </>
             )}
           </div>
 
-          <div className="ml-auto">
+          {/* Mobile nav — flex-1 fills the middle, scrollable if it overflows */}
+          <div className="flex-1 sm:hidden overflow-x-auto flex items-center gap-0.5 [&::-webkit-scrollbar]:hidden">
             {token ? (
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                className="px-5 py-2.5 text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg hover:shadow-xl transition-all relative overflow-hidden group"
-                onClick={handleLogout}
-              >
-                <span className="relative z-10">Logout</span>
-                <div className="absolute inset-0 bg-gradient-to-r from-white/15 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
-              </motion.button>
+              <>
+                <NavLink href="/social" text="Social" />
+                <NavLink href="/profile" text="Profile" />
+                <NavLink href="/hosting" text="Hosting" />
+                <NavLink href="/coding" text="Coding" />
+                <NavLink href="/smartcity" text="SmartCity" />
+                <NavLink href="/rygame" text="RyGame" />
+                <NavLink href="/cao" text="CAO" external />
+              </>
             ) : (
-              <div className="flex items-center gap-3">
+              <>
+                <NavLink href="/coding" text="Coding" />
+                <NavLink href="/smartcity" text="SmartCity" />
+                <NavLink href="/cao" text="CAO" external />
                 <NavLink href="/login" text="Login" />
-                <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-                  <Link
-                    href="/register"
-                    className="px-5 py-2.5 text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg hover:shadow-xl transition-all relative overflow-hidden group flex items-center"
-                  >
-                    <span className="relative z-10">Get Started</span>
-                    <div className="absolute inset-0 bg-gradient-to-r from-white/15 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
-                  </Link>
-                </motion.div>
-              </div>
+              </>
             )}
           </div>
-        </div>
 
-        {/* Mobile: logo + button row, then scrollable nav below */}
-        <div className="sm:hidden">
-          <div className="flex items-center justify-between h-14">
-            <Link href="/" className="flex items-center space-x-1.5 group">
-              <motion.div whileHover={{ rotate: 15 }} whileTap={{ scale: 0.95 }}>
-                <SparklesIcon className="h-6 w-6 text-purple-400" />
-              </motion.div>
-              <span className="text-xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
-                Adorio
-              </span>
-            </Link>
-
+          {/* Button — always right, never shrinks */}
+          <div className="ml-auto shrink-0">
             {token ? (
               <motion.button
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
-                className="px-3 py-1.5 text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white"
                 onClick={handleLogout}
+                className="px-3 sm:px-5 py-1.5 sm:py-2 text-xs sm:text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white font-medium shadow-md hover:shadow-lg transition-shadow"
               >
                 Logout
               </motion.button>
             ) : (
-              <Link
-                href="/register"
-                className="px-3 py-1.5 text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white"
-              >
-                Get Started
-              </Link>
-            )}
-          </div>
-
-          <div className="flex overflow-x-auto gap-1 pb-2 scrollbar-none">
-            {token ? (
-              <>
-                <NavLink href="/social" text="Social" />
-                <NavLink href="/profile" text="Profile" />
-                <NavLink href="/hosting" text="Hosting" />
-                <NavLink href="/coding" text="Coding" />
-                <NavLink href="/smartcity" text="SmartCity" />
-                <NavLink href="/rygame" text="RyGame" />
-                <NavLink href="/cao" text="CAO" external />
-              </>
-            ) : (
-              <>
-                <NavLink href="/coding" text="Coding" />
-                <NavLink href="/smartcity" text="SmartCity" />
-                <NavLink href="/cao" text="CAO" external />
-                <NavLink href="/login" text="Login" />
-              </>
+              <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                <Link
+                  href="/register"
+                  className="px-3 sm:px-5 py-1.5 sm:py-2 text-xs sm:text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white font-medium shadow-md hover:shadow-lg transition-shadow"
+                >
+                  Get Started
+                </Link>
+              </motion.div>
             )}
           </div>
         </div>
@@ -145,18 +113,18 @@ const Navbar = () => {
 };
 
 const NavLink = ({ href, text, className = '', external = false }) => (
-  <motion.div whileHover={{ scale: 1.05 }} className={`relative shrink-0 ${className}`}>
+  <motion.div whileHover={{ scale: 1.05 }} className={`shrink-0 ${className}`}>
     {external ? (
       <a
         href={href}
-        className="text-gray-300 px-3 py-2 text-sm font-medium hover:text-white transition-colors duration-200 flex items-center rounded-lg hover:bg-white/5"
+        className="block px-2.5 py-1.5 text-xs sm:text-sm font-medium text-gray-400 hover:text-white rounded-lg hover:bg-white/5 transition-colors whitespace-nowrap"
       >
         {text}
       </a>
     ) : (
       <Link
         href={href}
-        className="text-gray-300 px-3 py-2 text-sm font-medium hover:text-white transition-colors duration-200 flex items-center rounded-lg hover:bg-white/5"
+        className="block px-2.5 py-1.5 text-xs sm:text-sm font-medium text-gray-400 hover:text-white rounded-lg hover:bg-white/5 transition-colors whitespace-nowrap"
       >
         {text}
       </Link>

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -25,8 +25,8 @@ const NotFound = () => {
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!containerRef.current) return;
     const rect = containerRef.current.getBoundingClientRect();
-    mouseX.set(e.clientX - rect.left + window.scrollX);
-    mouseY.set(e.clientY - rect.top + window.scrollY);
+    mouseX.set(e.clientX - rect.left);
+    mouseY.set(e.clientY - rect.top);
   };
 
   useEffect(() => {

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -63,7 +63,7 @@ const NotFound = () => {
           rotateY: useTransform(smoothMouseX, [0, vw], [-8, 8]),
           transformPerspective: 1500,
         }}
-        className="relative w-full max-w-lg bg-gray-900/90 backdrop-blur-2xl border border-gray-700/50 rounded-3xl p-10 text-center shadow-2xl overflow-hidden"
+        className="relative w-full max-w-lg bg-gray-900/90 backdrop-blur-2xl border border-gray-700/50 rounded-3xl px-10 py-16 text-center shadow-2xl overflow-hidden"
       >
         <div className="absolute inset-0 bg-gradient-to-br from-purple-600/10 via-transparent to-blue-600/10 pointer-events-none" />
         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-purple-500/50 to-transparent" />

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -10,145 +10,136 @@ const NotFound = () => {
   const [vh, setVh] = useState(800);
   const [vw, setVw] = useState(1200);
   const router = useRouter();
-  const containerRef = useRef(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  // tracking mouse coords for all the fancy animations
   const mouseX = useMotionValue(0);
   const mouseY = useMotionValue(0);
   const smoothMouseX = useSpring(mouseX, { stiffness: 600, damping: 30 });
   const smoothMouseY = useSpring(mouseY, { stiffness: 600, damping: 30 });
 
-  // making the page look all cyberpunky with these lights
   const lightPosition = useTransform(
     [smoothMouseX, smoothMouseY],
     ([x, y]) => `calc(${x}px - 50%) calc(${y}px - 50%)`,
   );
 
-  const handleMouseMove = ({ clientX, clientY }) => {
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!containerRef.current) return;
     const rect = containerRef.current.getBoundingClientRect();
-    mouseX.set(clientX - rect.left + window.scrollX);
-    mouseY.set(clientY - rect.top + window.scrollY);
+    mouseX.set(e.clientX - rect.left + window.scrollX);
+    mouseY.set(e.clientY - rect.top + window.scrollY);
   };
 
   useEffect(() => {
     setVh(window.innerHeight);
     setVw(window.innerWidth);
     setRandomText(texts[Math.floor(Math.random() * texts.length)]);
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = 'auto';
-    };
   }, []);
 
   return (
     <div
       ref={containerRef}
-      className="min-h-screen bg-gray-950 flex items-center justify-center p-4 overflow-hidden"
+      className="fixed inset-0 bg-gray-950 flex items-center justify-center p-6 overflow-hidden"
       onMouseMove={handleMouseMove}
     >
-      {/* sick spotlight effect that follows your cursor - had to watch 3 tutorials to get this right */}
-      <motion.div
+      {/* Dot-grid background */}
+      <div
+        className="absolute inset-0 opacity-[0.15] pointer-events-none"
         style={{
-          backgroundPosition: lightPosition,
-          opacity: useTransform(
-            [smoothMouseX, smoothMouseY],
-            ([x, y]) =>
-              0.7 - Math.sqrt((x as number) * (x as number) + (y as number) * (y as number)) / 2000,
-          ),
+          backgroundImage: 'radial-gradient(circle, #6366f1 1px, transparent 1px)',
+          backgroundSize: '32px 32px',
         }}
-        className="fixed inset-0 pointer-events-none bg-[radial-gradient(400px_at_50%_50%,rgba(129,140,248,0.4),transparent)] backdrop-blur-[2px] transition-opacity duration-300"
       />
 
-      {/* main card that tilts with mouse movement */}
+      {/* Cursor spotlight */}
+      <motion.div
+        style={{ backgroundPosition: lightPosition }}
+        className="fixed inset-0 pointer-events-none bg-[radial-gradient(500px_at_50%_50%,rgba(129,140,248,0.12),transparent)]"
+      />
+
+      {/* Card */}
       <motion.div
         style={{
-          rotateX: useTransform(smoothMouseY, [0, vh], [15, -15]),
-          rotateY: useTransform(smoothMouseX, [0, vw], [-15, 15]),
-          transformPerspective: 2000,
+          rotateX: useTransform(smoothMouseY, [0, vh], [8, -8]),
+          rotateY: useTransform(smoothMouseX, [0, vw], [-8, 8]),
+          transformPerspective: 1500,
         }}
-        className="relative bg-gray-900/90 backdrop-blur-2xl border border-gray-800/60 rounded-3xl p-8 max-w-md text-center space-y-6 overflow-hidden shadow-2xl"
+        className="relative w-full max-w-lg bg-gray-900/90 backdrop-blur-2xl border border-gray-700/50 rounded-3xl p-10 text-center shadow-2xl overflow-hidden"
       >
-        {/* added this gradient for some depth */}
-        <div className="absolute inset-0 bg-gradient-to-br from-purple-600/10 to-blue-600/10 pointer-events-none" />
+        <div className="absolute inset-0 bg-gradient-to-br from-purple-600/10 via-transparent to-blue-600/10 pointer-events-none" />
+        <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-purple-500/50 to-transparent" />
 
-        {/* glowing icon at the top */}
         <motion.div
+          style={{
+            x: useTransform(smoothMouseX, [0, vw], [-12, 12]),
+            y: useTransform(smoothMouseY, [0, vh], [-12, 12]),
+          }}
+          className="flex justify-center mb-6"
+        >
+          <div className="relative">
+            <SparklesIcon className="h-14 w-14 text-purple-400 relative z-10" />
+            <div className="absolute inset-0 w-24 h-24 -translate-x-5 -translate-y-5 bg-purple-600/20 blur-[40px] rounded-full" />
+          </div>
+        </motion.div>
+
+        <motion.p
           style={{
             x: useTransform(smoothMouseX, [0, vw], [-20, 20]),
             y: useTransform(smoothMouseY, [0, vh], [-20, 20]),
           }}
-          className="flex justify-center relative"
+          className="text-sm font-semibold text-purple-400 tracking-widest uppercase mb-2"
         >
-          <SparklesIcon className="h-16 w-16 text-purple-400 relative z-10" />
-          <div className="absolute w-32 h-32 bg-purple-600/30 blur-[50px] rounded-full" />
-        </motion.div>
-
-        {/* big 404 text with shadow effect */}
-        <motion.h1
-          style={{
-            textShadow: '0 0 40px rgba(129,140,248,0.4)',
-            x: useTransform(smoothMouseX, [0, vw], [-30, 30]),
-            y: useTransform(smoothMouseY, [0, vh], [-30, 30]),
-          }}
-          className="text-8xl font-black bg-gradient-to-r from-purple-300 to-blue-300 bg-clip-text text-transparent relative"
-        >
-          404
-        </motion.h1>
-
-        {/* subtitle */}
-        <motion.p
-          style={{
-            x: useTransform(smoothMouseX, [0, vw], [-15, 15]),
-            y: useTransform(smoothMouseY, [0, vh], [-15, 15]),
-          }}
-          className="text-xl font-medium text-gray-300 uppercase tracking-widest"
-        >
-          Lost in the Void
+          404 — Page not found
         </motion.p>
 
-        {/* random funny error message */}
-        <motion.div
+        <motion.h1
           style={{
-            x: useTransform(smoothMouseX, [0, vw], [-10, 10]),
-            y: useTransform(smoothMouseY, [0, vh], [-10, 10]),
+            x: useTransform(smoothMouseX, [0, vw], [-16, 16]),
+            y: useTransform(smoothMouseY, [0, vh], [-16, 16]),
           }}
-          className="text-gray-400 text-lg italic px-4 relative"
+          className="text-4xl font-black text-white mb-4"
         >
-          <span className="relative z-10">{randomText}</span>
-          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-purple-600/15 to-transparent opacity-0 hover:opacity-100 transition-opacity duration-300" />
-        </motion.div>
+          Lost in the Void
+        </motion.h1>
 
-        {/* back button */}
-        <motion.button
-          onClick={() => router.push('/')}
-          whileHover={{ scale: 1.05 }}
-          whileTap={{ scale: 0.95 }}
+        <motion.p
           style={{
-            x: useTransform(smoothMouseX, [0, vw], [-10, 10]),
-            y: useTransform(smoothMouseY, [0, vh], [-10, 10]),
+            x: useTransform(smoothMouseX, [0, vw], [-8, 8]),
+            y: useTransform(smoothMouseY, [0, vh], [-8, 8]),
           }}
-          className="inline-flex items-center px-8 py-3.5 rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold shadow-xl hover:shadow-2xl transition-all duration-300 relative overflow-hidden group"
+          className="text-gray-400 text-base italic mb-8 leading-relaxed"
         >
-          <span className="relative z-10 flex items-center gap-2">
-            <span>Return to Reality</span>
-            <motion.svg
-              viewBox="0 0 24 24"
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              animate={{ x: [0, 2, 0] }}
-              transition={{ duration: 1.2, repeat: Infinity }}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13 7l5 5m0 0l-5 5m5-5H6"
-              />
-            </motion.svg>
-          </span>
-          <div className="absolute inset-0 bg-gradient-to-r from-white/25 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-        </motion.button>
+          {randomText}
+        </motion.p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <motion.button
+            onClick={() => router.back()}
+            whileHover={{ scale: 1.03 }}
+            whileTap={{ scale: 0.97 }}
+            className="px-6 py-3 rounded-xl border border-gray-700 text-gray-300 text-sm font-medium hover:bg-white/5 transition-colors"
+          >
+            Go back
+          </motion.button>
+          <motion.button
+            onClick={() => router.push('/')}
+            whileHover={{ scale: 1.03 }}
+            whileTap={{ scale: 0.97 }}
+            className="px-6 py-3 rounded-xl bg-gradient-to-r from-purple-600 to-blue-600 text-white text-sm font-semibold shadow-lg hover:shadow-purple-500/25 transition-all relative overflow-hidden group"
+          >
+            <span className="relative z-10 flex items-center justify-center gap-2">
+              Return home
+              <svg viewBox="0 0 24 24" className="w-4 h-4" fill="none" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7l5 5m0 0l-5 5m5-5H6"
+                />
+              </svg>
+            </span>
+            <div className="absolute inset-0 bg-white/10 opacity-0 group-hover:opacity-100 transition-opacity" />
+          </motion.button>
+        </div>
       </motion.div>
     </div>
   );

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -23,7 +23,6 @@ const Home = ({ initialPosts = [], initialHasMore = true }) => {
   const [imagePreview, setImagePreview] = useState('');
   const [hasMore, setHasMore] = useState(initialHasMore);
   const [page, setPage] = useState(initialPosts.length > 0 ? 2 : 1);
-  const [objectUrls, setObjectUrls] = useState([]);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
   // Prevent hydration mismatch: user-dependent UI only renders after client mount
   const [mounted, setMounted] = useState(false);
@@ -300,12 +299,7 @@ const Home = ({ initialPosts = [], initialHasMore = true }) => {
     <div className="relative min-h-screen bg-gray-950 pb-16 sm:pb-0">
       <AnimatePresence>{error && <ErrorMessage error={error} />}</AnimatePresence>
 
-      <div className="container mx-auto max-w-2xl px-2 sm:px-4 py-6 sm:py-8 pt-16 sm:pt-20">
-        {loading && (
-          <motion.div className="text-center py-6">
-            <p className="text-gray-400">Loading new posts...</p>
-          </motion.div>
-        )}
+      <div className="container mx-auto max-w-2xl px-2 sm:px-4 py-6 sm:py-8 pt-6 sm:pt-8">
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -423,18 +417,14 @@ const Home = ({ initialPosts = [], initialHasMore = true }) => {
           </motion.div>
         )}
 
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          className="space-y-4 sm:space-y-6 pb-8"
-        >
-          {posts.map((post, index) => (
-            <React.Fragment key={post._id}>
-              <motion.div
-                initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: 'auto' }}
-                exit={{ opacity: 0, height: 0 }}
-                className="relative  mt-4 pt-4 border-t border-gray-800/40"
+        <div className="space-y-4 sm:space-y-5 pb-8">
+          {loading && posts.length === 0 ? (
+            <SkeletonLoader count={3} />
+          ) : (
+            posts.map((post, index) => (
+              <div
+                key={post._id}
+                className="border-t border-gray-800/40 pt-4"
                 ref={index === posts.length - 1 ? lastPostRef : null}
               >
                 <PostCard
@@ -448,22 +438,23 @@ const Home = ({ initialPosts = [], initialHasMore = true }) => {
                     );
                   }}
                 />
-              </motion.div>
-            </React.Fragment>
-          ))}
-
-          {loading && <SkeletonLoader count={3} />}
-
-          {!loading && !hasMore && (
-            <motion.div
-              initial={{ scale: 0.95 }}
-              animate={{ scale: 1 }}
-              className="text-center py-6 sm:py-8 bg-gray-900/50 rounded-lg border border-gray-800/40"
-            >
-              <p className="text-sm sm:text-base text-gray-400">No more posts to load</p>
-            </motion.div>
+              </div>
+            ))
           )}
-        </motion.div>
+
+          {isFetchingMore && <SkeletonLoader count={2} />}
+
+          {!loading && !hasMore && posts.length > 0 && (
+            <p className="text-center py-6 text-sm text-gray-500">You&apos;ve reached the end</p>
+          )}
+
+          {!loading && posts.length === 0 && !error && (
+            <div className="text-center py-16">
+              <SparklesIcon className="h-10 w-10 text-gray-700 mx-auto mb-3" />
+              <p className="text-gray-500">No posts yet. Be the first to post!</p>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/views/Hosting/index.tsx
+++ b/src/views/Hosting/index.tsx
@@ -64,7 +64,7 @@ export default function HostingView() {
     } catch {
       setError('Failed to delete file');
     } finally {
-      setDeletingSlug('');
+      setDeletingSlug((prev) => (prev === slug ? '' : prev));
     }
   };
 
@@ -210,8 +210,8 @@ export default function HostingView() {
                       </p>
                       <p className="font-mono text-xs text-purple-400 mt-0.5">/h/{f.slug}</p>
                       <p className="text-xs text-gray-600 mt-0.5">
-                        {(f.size / 1024).toFixed(1)} KB &middot;{' '}
-                        {f.views === 1 ? '1 view' : `${f.views} views`} &middot;{' '}
+                        {f.size >= 1024 ? `${(f.size / 1024).toFixed(1)} KB` : `${f.size} B`}{' '}
+                        &middot; {f.views === 1 ? '1 view' : `${f.views} views`} &middot;{' '}
                         {new Date(f.createdAt).toLocaleDateString()}
                       </p>
                     </div>
@@ -227,7 +227,7 @@ export default function HostingView() {
                         target="_blank"
                         rel="noreferrer"
                         className="rounded-lg bg-gray-800 p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
-                        title="View"
+                        aria-label={`View ${f.originalFilename}`}
                       >
                         <EyeIcon className="h-4 w-4" />
                       </a>
@@ -235,7 +235,7 @@ export default function HostingView() {
                         onClick={() => handleDelete(f.slug)}
                         disabled={deletingSlug === f.slug}
                         className="rounded-lg bg-red-950/40 p-1.5 text-red-500 hover:bg-red-950/70 hover:text-red-400 transition-colors disabled:opacity-50"
-                        title="Delete"
+                        aria-label={`Delete ${f.originalFilename}`}
                       >
                         <TrashIcon className="h-4 w-4" />
                       </button>

--- a/src/views/Hosting/index.tsx
+++ b/src/views/Hosting/index.tsx
@@ -7,6 +7,8 @@ import {
   deleteHostedFile,
   type HostedFile,
 } from '@/api/hosting';
+import { CloudArrowUpIcon, DocumentIcon, TrashIcon, EyeIcon } from '@heroicons/react/24/outline';
+import { motion, AnimatePresence } from 'framer-motion';
 
 export default function HostingView() {
   const [files, setFiles] = useState<HostedFile[]>([]);
@@ -15,6 +17,7 @@ export default function HostingView() {
   const [error, setError] = useState('');
   const [copied, setCopied] = useState('');
   const [dragging, setDragging] = useState(false);
+  const [deletingSlug, setDeletingSlug] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -54,11 +57,14 @@ export default function HostingView() {
   };
 
   const handleDelete = async (slug: string) => {
+    setDeletingSlug(slug);
     try {
       await deleteHostedFile(slug);
       setFiles((prev) => prev.filter((f) => f.slug !== slug));
     } catch {
       setError('Failed to delete file');
+    } finally {
+      setDeletingSlug('');
     }
   };
 
@@ -68,21 +74,45 @@ export default function HostingView() {
     setTimeout(() => setCopied(''), 2000);
   };
 
-  return (
-    <div className="min-h-screen bg-gray-950 px-4 py-8 pt-20">
-      <div className="mx-auto max-w-3xl">
-        <h1 className="mb-1 text-2xl font-bold text-white">File Hosting</h1>
-        <p className="mb-8 text-sm text-gray-400">
-          Upload an HTML file and share it instantly at{' '}
-          <span className="font-mono text-purple-400">adorio.space/h/your-filename</span>. No deploy
-          required.
-        </p>
+  const totalViews = files.reduce((sum, f) => sum + f.views, 0);
+  const totalSize = files.reduce((sum, f) => sum + f.size, 0);
 
+  return (
+    <div className="min-h-screen bg-gray-950 px-4 py-8">
+      <div className="mx-auto max-w-2xl">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-white mb-1">File Hosting</h1>
+          <p className="text-gray-400 text-sm">
+            Upload an HTML file — get a shareable link instantly at{' '}
+            <span className="font-mono text-purple-400">adorio.space/h/your-file</span>
+          </p>
+        </div>
+
+        {/* Stats row */}
+        {!loading && files.length > 0 && (
+          <div className="grid grid-cols-3 gap-3 mb-6">
+            {[
+              { label: 'Files', value: files.length },
+              { label: 'Total views', value: totalViews.toLocaleString() },
+              {
+                label: 'Storage used',
+                value: totalSize >= 1024 ? `${(totalSize / 1024).toFixed(1)} KB` : `${totalSize} B`,
+              },
+            ].map((s) => (
+              <div key={s.label} className="bg-gray-900 rounded-xl p-4 border border-gray-800/50">
+                <p className="text-2xl font-bold text-white">{s.value}</p>
+                <p className="text-xs text-gray-500 mt-0.5">{s.label}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Upload zone */}
         <div
-          className={`mb-6 cursor-pointer rounded-xl border-2 border-dashed p-12 text-center transition-colors ${
+          className={`mb-6 rounded-2xl border-2 border-dashed transition-all cursor-pointer ${
             dragging
-              ? 'border-purple-500 bg-purple-500/10'
-              : 'border-gray-700 hover:border-gray-500'
+              ? 'border-purple-500 bg-purple-500/10 scale-[1.01]'
+              : 'border-gray-700 hover:border-gray-500 hover:bg-white/[0.02]'
           }`}
           onClick={() => fileInputRef.current?.click()}
           onDragOver={(e) => {
@@ -103,67 +133,119 @@ export default function HostingView() {
               e.target.value = '';
             }}
           />
-          {uploading ? (
-            <p className="text-gray-400">Uploading…</p>
-          ) : (
-            <>
-              <p className="text-gray-300">Drop an HTML file here or click to browse</p>
-              <p className="mt-1 text-xs text-gray-500">Only .html · max 512 KB</p>
-            </>
-          )}
+          <div className="py-10 flex flex-col items-center gap-3">
+            {uploading ? (
+              <>
+                <div className="h-8 w-8 rounded-full border-2 border-purple-500 border-t-transparent animate-spin" />
+                <p className="text-sm text-gray-400">Uploading…</p>
+              </>
+            ) : (
+              <>
+                <CloudArrowUpIcon
+                  className={`h-10 w-10 transition-colors ${dragging ? 'text-purple-400' : 'text-gray-600'}`}
+                />
+                <div className="text-center">
+                  <p className="text-gray-300 text-sm font-medium">
+                    Drop an HTML file or{' '}
+                    <span className="text-purple-400 underline underline-offset-2">browse</span>
+                  </p>
+                  <p className="text-xs text-gray-600 mt-1">Only .html · max 512 KB</p>
+                </div>
+              </>
+            )}
+          </div>
         </div>
 
-        {error && (
-          <p className="mb-5 rounded-lg bg-red-950/50 px-4 py-2.5 text-sm text-red-400">{error}</p>
-        )}
-
-        <h2 className="mb-3 text-lg font-semibold text-white">Your files</h2>
-
-        {loading ? (
-          <p className="text-sm text-gray-500">Loading…</p>
-        ) : files.length === 0 ? (
-          <p className="text-sm text-gray-500">No files hosted yet.</p>
-        ) : (
-          <div className="space-y-3">
-            {files.map((f) => (
-              <div
-                key={f._id}
-                className="flex items-center justify-between gap-4 rounded-xl bg-gray-900 px-5 py-4"
+        <AnimatePresence>
+          {error && (
+            <motion.div
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0 }}
+              className="mb-5 flex items-center justify-between gap-3 rounded-xl bg-red-950/40 border border-red-900/50 px-4 py-3"
+            >
+              <p className="text-sm text-red-400">{error}</p>
+              <button
+                onClick={() => setError('')}
+                className="text-red-500 hover:text-red-300 text-xs shrink-0"
               >
-                <div className="min-w-0">
-                  <p className="truncate font-medium text-white">{f.originalFilename}</p>
-                  <p className="mt-0.5 font-mono text-xs text-purple-400">/h/{f.slug}</p>
-                  <p className="mt-0.5 text-xs text-gray-500">
-                    {(f.size / 1024).toFixed(1)} KB &middot; {f.views} view
-                    {f.views !== 1 ? 's' : ''} &middot; {new Date(f.createdAt).toLocaleDateString()}
-                  </p>
-                </div>
-                <div className="flex shrink-0 gap-2">
-                  <button
-                    onClick={() => copyUrl(f.slug)}
-                    className="rounded-lg bg-gray-800 px-3 py-1.5 text-xs text-gray-300 transition-colors hover:bg-gray-700"
+                Dismiss
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* File list */}
+        <div>
+          <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">
+            Your files
+          </h2>
+
+          {loading ? (
+            <div className="space-y-3">
+              {[1, 2].map((i) => (
+                <div key={i} className="h-20 rounded-xl bg-gray-900 animate-pulse" />
+              ))}
+            </div>
+          ) : files.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-gray-800 py-16 flex flex-col items-center gap-2">
+              <DocumentIcon className="h-8 w-8 text-gray-700" />
+              <p className="text-sm text-gray-600">No files yet — upload one above</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <AnimatePresence>
+                {files.map((f) => (
+                  <motion.div
+                    key={f._id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, x: -20 }}
+                    className="flex items-center gap-4 rounded-xl bg-gray-900 border border-gray-800/50 px-5 py-4 hover:border-gray-700/50 transition-colors"
                   >
-                    {copied === f.slug ? 'Copied!' : 'Copy URL'}
-                  </button>
-                  <a
-                    href={`/h/${f.slug}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="rounded-lg bg-gray-800 px-3 py-1.5 text-xs text-gray-300 transition-colors hover:bg-gray-700"
-                  >
-                    View
-                  </a>
-                  <button
-                    onClick={() => handleDelete(f.slug)}
-                    className="rounded-lg bg-red-950/50 px-3 py-1.5 text-xs text-red-400 transition-colors hover:bg-red-950/80"
-                  >
-                    Delete
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+                    <DocumentIcon className="h-5 w-5 text-gray-600 shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-white">
+                        {f.originalFilename}
+                      </p>
+                      <p className="font-mono text-xs text-purple-400 mt-0.5">/h/{f.slug}</p>
+                      <p className="text-xs text-gray-600 mt-0.5">
+                        {(f.size / 1024).toFixed(1)} KB &middot;{' '}
+                        {f.views === 1 ? '1 view' : `${f.views} views`} &middot;{' '}
+                        {new Date(f.createdAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <button
+                        onClick={() => copyUrl(f.slug)}
+                        className="rounded-lg bg-gray-800 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-700 transition-colors min-w-[72px] text-center"
+                      >
+                        {copied === f.slug ? '✓ Copied' : 'Copy URL'}
+                      </button>
+                      <a
+                        href={`/h/${f.slug}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="rounded-lg bg-gray-800 p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 transition-colors"
+                        title="View"
+                      >
+                        <EyeIcon className="h-4 w-4" />
+                      </a>
+                      <button
+                        onClick={() => handleDelete(f.slug)}
+                        disabled={deletingSlug === f.slug}
+                        className="rounded-lg bg-red-950/40 p-1.5 text-red-500 hover:bg-red-950/70 hover:text-red-400 transition-colors disabled:opacity-50"
+                        title="Delete"
+                      >
+                        <TrashIcon className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Navbar**: Single flex row at every viewport — logo left, desktop nav absolutely centered, mobile nav scrollable in the middle, button always right. No more two-row mobile layout. Added Hosting link for logged-in users.
- **404 page**: `fixed inset-0` full-screen layout with dot-grid background, correct cursor spotlight math (removed stale scroll offsets), more vertical padding on card (`py-16`), "Go back" + "Return home" buttons.
- **Portfolio default theme**: One Dark instead of Midnight.
- **Social feed**: Initial load shows skeleton cards; removed dead `objectUrls` state; cleaner empty state and end-of-feed copy.
- **Hosting page**: Stats row (files / total views / storage used); animated file rows; icon-only View/Delete with `aria-label`; skeleton loaders; race-condition-safe delete spinner; consistent file size formatting.

## Test plan
- [ ] Navbar: links are centered on desktop, single scrollable row on mobile
- [ ] Hosting link appears in nav when logged in
- [ ] /404 fills the full viewport with dot-grid background and extra card padding
- [ ] Portfolio root loads with One Dark theme by default
- [ ] /social initial load shows skeleton cards, not a text message
- [ ] /hosting stats row appears after files exist; delete spinner doesn't flicker on concurrent deletes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app’s default theme to **One Dark**.
  * Improved the hosting page with upload progress, file stats, and clearer file actions.
  * Added a refined 404 page with new navigation options and visual effects.

* **Bug Fixes**
  * Simplified the home feed loading and empty-state behavior for a smoother scrolling experience.
  * Improved navigation layout on desktop and mobile for more consistent linking and access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->