### PR TITLE
fix(nav): proper navbar with hamburger on mobile, centered links on desktop

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,37 +1,60 @@
 'use client';
+import { useState } from 'react';
 import Link from 'next/link';
-import PropTypes from 'prop-types';
 import { useRouter, usePathname } from 'next/navigation';
-import { SparklesIcon } from '@heroicons/react/24/outline';
+import { SparklesIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { logout } from '../store/userSlice';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
+
+type NavItem = { href: string; text: string; external?: boolean };
 
 const Navbar = () => {
   const { token } = useAppSelector((state) => state.user);
   const dispatch = useAppDispatch();
   const router = useRouter();
   const pathname = usePathname();
+  const [open, setOpen] = useState(false);
 
   if (pathname === '/') return null;
+
+  const close = () => setOpen(false);
 
   const handleLogout = () => {
     dispatch(logout());
     router.push('/login');
+    close();
   };
+
+  const links: NavItem[] = token
+    ? [
+        { href: '/social', text: 'Social' },
+        { href: '/profile', text: 'Profile' },
+        { href: '/hosting', text: 'Hosting' },
+        { href: '/coding', text: 'Coding' },
+        { href: '/smartcity', text: 'SmartCity' },
+        { href: '/rygame', text: 'RyGame' },
+        { href: '/cao', text: 'CAO', external: true },
+      ]
+    : [
+        { href: '/coding', text: 'Coding' },
+        { href: '/smartcity', text: 'SmartCity' },
+        { href: '/cao', text: 'CAO', external: true },
+        { href: '/login', text: 'Login' },
+      ];
 
   return (
     <motion.nav
-      initial={{ y: -100 }}
+      initial={{ y: -64 }}
       animate={{ y: 0 }}
-      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 25 }}
       className="sticky top-0 z-50 bg-gray-950/95 backdrop-blur-lg border-b border-gray-800 shadow-lg"
     >
-      <div className="container mx-auto px-3 sm:px-4">
-        {/* Single row at every viewport: [logo] [nav fills middle] [button] */}
-        <div className="flex items-center h-14 sm:h-16 gap-2 relative">
-          {/* Logo — always left, never shrinks */}
-          <Link href="/" className="flex items-center gap-1.5 shrink-0 group">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        {/* ── Single bar ─────────────────────────────────────── */}
+        <div className="flex items-center h-14 sm:h-16">
+          {/* Logo */}
+          <Link href="/" className="flex items-center gap-2 shrink-0 mr-6">
             <motion.div whileHover={{ rotate: 15 }} whileTap={{ scale: 0.9 }}>
               <SparklesIcon className="h-5 w-5 sm:h-6 sm:w-6 text-purple-400" />
             </motion.div>
@@ -40,103 +63,119 @@ const Navbar = () => {
             </span>
           </Link>
 
-          {/* Desktop nav — absolutely centered so it doesn't shift with logo/button widths */}
-          <div className="absolute left-1/2 -translate-x-1/2 hidden sm:flex items-center gap-0.5">
-            {token ? (
-              <>
-                <NavLink href="/social" text="Social" />
-                <NavLink href="/profile" text="Profile" />
-                <NavLink href="/hosting" text="Hosting" />
-                <NavLink href="/coding" text="Coding" />
-                <NavLink href="/smartcity" text="SmartCity" />
-                <NavLink href="/rygame" text="RyGame" />
-                <NavLink href="/cao" text="CAO" external />
-              </>
-            ) : (
-              <>
-                <NavLink href="/coding" text="Coding" />
-                <NavLink href="/smartcity" text="SmartCity" />
-                <NavLink href="/cao" text="CAO" external />
-                <NavLink href="/login" text="Login" />
-              </>
-            )}
-          </div>
-
-          {/* Mobile nav — flex-1 fills the middle, scrollable if it overflows */}
-          <div className="flex-1 sm:hidden overflow-x-auto flex items-center gap-0.5 [&::-webkit-scrollbar]:hidden">
-            {token ? (
-              <>
-                <NavLink href="/social" text="Social" />
-                <NavLink href="/profile" text="Profile" />
-                <NavLink href="/hosting" text="Hosting" />
-                <NavLink href="/coding" text="Coding" />
-                <NavLink href="/smartcity" text="SmartCity" />
-                <NavLink href="/rygame" text="RyGame" />
-                <NavLink href="/cao" text="CAO" external />
-              </>
-            ) : (
-              <>
-                <NavLink href="/coding" text="Coding" />
-                <NavLink href="/smartcity" text="SmartCity" />
-                <NavLink href="/cao" text="CAO" external />
-                <NavLink href="/login" text="Login" />
-              </>
-            )}
-          </div>
-
-          {/* Button — always right, never shrinks */}
-          <div className="ml-auto shrink-0">
-            {token ? (
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={handleLogout}
-                className="px-3 sm:px-5 py-1.5 sm:py-2 text-xs sm:text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white font-medium shadow-md hover:shadow-lg transition-shadow"
-              >
-                Logout
-              </motion.button>
-            ) : (
-              <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-                <Link
-                  href="/register"
-                  className="px-3 sm:px-5 py-1.5 sm:py-2 text-xs sm:text-sm rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white font-medium shadow-md hover:shadow-lg transition-shadow"
+          {/* Desktop nav — fills middle, links are centered within it */}
+          <div className="hidden sm:flex flex-1 items-center justify-center gap-0.5">
+            {links.map(({ href, text, external }) =>
+              external ? (
+                <a
+                  key={href}
+                  href={href}
+                  className="px-3 py-2 text-sm font-medium text-gray-400 hover:text-white rounded-lg hover:bg-white/5 transition-colors whitespace-nowrap"
                 >
-                  Get Started
+                  {text}
+                </a>
+              ) : (
+                <Link
+                  key={href}
+                  href={href}
+                  className="px-3 py-2 text-sm font-medium text-gray-400 hover:text-white rounded-lg hover:bg-white/5 transition-colors whitespace-nowrap"
+                >
+                  {text}
                 </Link>
-              </motion.div>
+              ),
             )}
           </div>
+
+          {/* Desktop action button */}
+          {token ? (
+            <motion.button
+              whileHover={{ scale: 1.04 }}
+              whileTap={{ scale: 0.96 }}
+              onClick={handleLogout}
+              className="hidden sm:block ml-6 shrink-0 px-5 py-2 text-sm font-medium rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:opacity-90 transition-opacity"
+            >
+              Logout
+            </motion.button>
+          ) : (
+            <motion.div whileHover={{ scale: 1.04 }} whileTap={{ scale: 0.96 }}>
+              <Link
+                href="/register"
+                className="hidden sm:block ml-6 shrink-0 px-5 py-2 text-sm font-medium rounded-full bg-gradient-to-r from-purple-600 to-blue-600 text-white hover:opacity-90 transition-opacity"
+              >
+                Get Started
+              </Link>
+            </motion.div>
+          )}
+
+          {/* Mobile hamburger */}
+          <button
+            onClick={() => setOpen((v) => !v)}
+            className="sm:hidden ml-auto p-2 rounded-lg text-gray-400 hover:text-white hover:bg-white/5 transition-colors"
+            aria-label="Toggle navigation menu"
+          >
+            {open ? <XMarkIcon className="h-5 w-5" /> : <Bars3Icon className="h-5 w-5" />}
+          </button>
         </div>
       </div>
+
+      {/* Mobile dropdown */}
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            key="mobile-menu"
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="sm:hidden overflow-hidden border-t border-gray-800 bg-gray-950"
+          >
+            <div className="max-w-6xl mx-auto px-4 py-2 flex flex-col">
+              {links.map(({ href, text, external }) =>
+                external ? (
+                  <a
+                    key={href}
+                    href={href}
+                    onClick={close}
+                    className="px-3 py-3 text-sm text-gray-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+                  >
+                    {text}
+                  </a>
+                ) : (
+                  <Link
+                    key={href}
+                    href={href}
+                    onClick={close}
+                    className="px-3 py-3 text-sm text-gray-300 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+                  >
+                    {text}
+                  </Link>
+                ),
+              )}
+
+              <div className="mt-2 pt-2 border-t border-gray-800">
+                {token ? (
+                  <button
+                    onClick={handleLogout}
+                    className="w-full text-left px-3 py-3 text-sm text-red-400 hover:text-red-300 hover:bg-red-950/30 rounded-lg transition-colors"
+                  >
+                    Logout
+                  </button>
+                ) : (
+                  <Link
+                    href="/register"
+                    onClick={close}
+                    className="block px-3 py-3 text-sm font-semibold text-purple-400 hover:text-purple-300 hover:bg-purple-950/30 rounded-lg transition-colors"
+                  >
+                    Get Started
+                  </Link>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </motion.nav>
   );
-};
-
-const NavLink = ({ href, text, className = '', external = false }) => (
-  <motion.div whileHover={{ scale: 1.05 }} className={`shrink-0 ${className}`}>
-    {external ? (
-      <a
-        href={href}
-        className="block px-2.5 py-1.5 text-xs sm:text-sm font-medium text-gray-400 hover:text-white rounded-lg hover:bg-white/5 transition-colors whitespace-nowrap"
-      >
-        {text}
-      </a>
-    ) : (
-      <Link
-        href={href}
-        className="block px-2.5 py-1.5 text-xs sm:text-sm font-medium text-gray-400 hover:text-white rounded-lg hover:bg-white/5 transition-colors whitespace-nowrap"
-      >
-        {text}
-      </Link>
-    )}
-  </motion.div>
-);
-
-NavLink.propTypes = {
-  href: PropTypes.string.isRequired,
-  text: PropTypes.string.isRequired,
-  className: PropTypes.string,
-  external: PropTypes.bool,
 };
 
 export default Navbar;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import { SparklesIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
-import { useAppDispatch, useAppSelector } from '../store/hooks';
-import { logout } from '../store/userSlice';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { logout } from '@/store/userSlice';
 import { motion, AnimatePresence } from 'framer-motion';
 
 type NavItem = { href: string; text: string; external?: boolean };


### PR DESCRIPTION
## Summary
Complete navbar rewrite — the previous approach was squishing links against the logo on narrower viewports.

**Desktop (≥ sm breakpoint):**
- Logo left with fixed gap
- Nav links in a `flex-1 justify-center` middle — truly centered regardless of logo/button widths
- Action button (Logout / Get Started) pinned right

**Mobile (< sm breakpoint):**
- Logo left, hamburger icon right — clean single bar
- Tap hamburger → animated dropdown lists all nav links vertically, closes on link click
- Logout/Get Started at the bottom of the dropdown separated by a divider

## Test plan
- [ ] Desktop: nav links are centered between logo and button at all wide viewport widths
- [ ] Mobile: only logo + hamburger icon show in the bar (no squished links)
- [ ] Mobile: tapping hamburger opens animated dropdown with all links
- [ ] Mobile: tapping any link closes the dropdown
- [ ] Logged-in nav includes Hosting link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the navigation menu with a cleaner desktop layout and a new mobile dropdown experience.
  * Navigation options now change based on whether you’re signed in, showing the appropriate actions automatically.
  * Added a hamburger menu on mobile with smoother open/close behavior and auto-closing links after selection.

* **Bug Fixes**
  * Improved logout flow so it now signs you out, sends you to the login screen, and closes the mobile menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->