### PR TITLE
feat(ci): deploy to azure container apps instead of ssh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,20 +86,25 @@ jobs:
         run: npm run test:prod
 
   deploy:
-    name: Deploy to droplet
+    name: Deploy to Azure Container Apps
     runs-on: ubuntu-latest
     needs: integration
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
+      - uses: actions/checkout@v4
+      - uses: azure/login@v3
         with:
-          host: ${{ secrets.DROPLET_IP }}
-          username: root
-          key: ${{ secrets.DROPLET_SSH_KEY }}
-          command_timeout: 30m
-          script: |
-            cd ~/Adorio
-            git pull origin main
-            export VITE_GEMINI_API_KEY="${{ secrets.VITE_GEMINI_API_KEY }}"
-            npm run docker:redeploy
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Build and push image
+        run: |
+          az acr build --registry adorioacr --image adorio:${{ github.sha }} \
+            --build-arg VITE_GEMINI_API_KEY=${{ secrets.VITE_GEMINI_API_KEY }} .
+      - name: Deploy new revision
+        run: |
+          az containerapp update --name adorio --resource-group adorio-prod-rg \
+            --image adorioacr.azurecr.io/adorio:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
       - uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -108,3 +111,5 @@ jobs:
         run: |
           az containerapp update --name adorio --resource-group adorio-prod-rg \
             --image adorioacr.azurecr.io/adorio:${{ github.sha }}
+      - name: Verify deployment health
+        run: node scripts/wait-for-url.cjs https://adorio.orangeground-7d1e6e2f.southeastasia.azurecontainerapps.io/api/health 180000 2000


### PR DESCRIPTION
## Summary
- PR 3 of the DO → Azure Container Apps migration — replaces the `deploy` job's SSH-based droplet deploy with a real Azure Container Apps rollout
- Auth via `azure/login@v3` using OIDC (`id-token: write` permission, no client secret stored anywhere) — client-id/tenant-id/subscription-id secrets identify the user-assigned managed identity from PR 2, whose federated credential trusts only `repo:Mykal-Steele/Adorio:ref:refs/heads/main`
- `az acr build` builds the existing multi-stage Dockerfile in ACR Tasks (cloud-side, no Docker-in-Docker on the runner) and pushes to `adorioacr`
- `az containerapp update` rolls out the new image — the `/api/health` liveness/readiness probes from PR 2 gate the rollout, so a broken revision never takes traffic
- `format`, `lint`, `build`, and `integration` jobs are untouched

## Infra is live
Ahead of this PR (not part of the diff, done via the plan's Rollout checklist):
- `infra/main.bicep` applied for real against `adorio-prod-rg` in `southeastasia`
- GitHub secrets `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` added; `DROPLET_IP` / `DROPLET_SSH_KEY` removed (dead — droplet's already shut down)
- Runtime secrets baked into the Container App directly through the Bicep deployment (`@secure()` params read from the local `.env.production` via `readEnvironmentVariable()`, never committed)
- `REFRESH_TOKEN_SECRET` had never actually existed as a GitHub secret or in any local `.env` file (confirmed — CI's integration tests have silently been running with it empty this whole time, falling back to `JWT_SECRET`). Generated a dedicated one for the real deployment and saved it to local `backend/.env`.

## Test plan
- [x] `npm run format:check` / `npm run lint` — clean
- [x] YAML-parsed the workflow to confirm structure is valid
- [ ] First real deploy on merge — will watch this run end-to-end and confirm the revision goes healthy