### PR TITLE
fix(infra): acr build permissions, image safety, and a spend budget

### DIFF
--- a/infra/budget.bicep
+++ b/infra/budget.bicep
@@ -6,8 +6,12 @@ param amount int = 150
 @description('Email to notify when spend crosses a threshold')
 param contactEmail string = 'mykal.stele@gmail.com'
 
-@description('First-of-month start date for the budget period (Monthly time grain re-evaluates automatically every month after this)')
-param startDate string = '2026-08-01T00:00:00Z'
+// utcNow() only works as a parameter default — computed at deploy time, not committed
+// as a fixed value. Needed because a hardcoded date would eventually fall outside the
+// "past start date must be within the current time-grain period" rule on any future
+// redeploy of this same template (e.g. touching notification thresholds later).
+@description('First-of-month start date for the budget period — always computed as the current month, not fixed, so redeploying this template months from now still works')
+param startDate string = utcNow('yyyy-MM-01T00:00:00Z')
 
 resource monthlyBudget 'Microsoft.Consumption/budgets@2024-08-01' = {
   name: 'adorio-monthly-credit'
@@ -33,16 +37,16 @@ resource monthlyBudget 'Microsoft.Consumption/budgets@2024-08-01' = {
         thresholdType: 'Actual'
         contactEmails: [contactEmail]
       }
-      Actual_GreaterThan_100_Percent: {
+      Actual_GreaterThanOrEqualTo_100_Percent: {
         enabled: true
-        operator: 'GreaterThan'
+        operator: 'GreaterThanOrEqualTo'
         threshold: 100
         thresholdType: 'Actual'
         contactEmails: [contactEmail]
       }
-      Forecasted_GreaterThan_100_Percent: {
+      Forecasted_GreaterThanOrEqualTo_100_Percent: {
         enabled: true
-        operator: 'GreaterThan'
+        operator: 'GreaterThanOrEqualTo'
         threshold: 100
         thresholdType: 'Forecasted'
         contactEmails: [contactEmail]

--- a/infra/budget.bicep
+++ b/infra/budget.bicep
@@ -1,0 +1,52 @@
+targetScope = 'subscription'
+
+@description('Monthly budget amount in USD — matches the recurring Visual Studio Enterprise credit, not a hard cap Azure enforces')
+param amount int = 150
+
+@description('Email to notify when spend crosses a threshold')
+param contactEmail string = 'mykal.stele@gmail.com'
+
+@description('First-of-month start date for the budget period (Monthly time grain re-evaluates automatically every month after this)')
+param startDate string = '2026-08-01T00:00:00Z'
+
+resource monthlyBudget 'Microsoft.Consumption/budgets@2024-08-01' = {
+  name: 'adorio-monthly-credit'
+  properties: {
+    category: 'Cost'
+    amount: amount
+    timeGrain: 'Monthly'
+    timePeriod: {
+      startDate: startDate
+    }
+    notifications: {
+      Actual_GreaterThan_50_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 50
+        thresholdType: 'Actual'
+        contactEmails: [contactEmail]
+      }
+      Actual_GreaterThan_80_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 80
+        thresholdType: 'Actual'
+        contactEmails: [contactEmail]
+      }
+      Actual_GreaterThan_100_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 100
+        thresholdType: 'Actual'
+        contactEmails: [contactEmail]
+      }
+      Forecasted_GreaterThan_100_Percent: {
+        enabled: true
+        operator: 'GreaterThan'
+        threshold: 100
+        thresholdType: 'Forecasted'
+        contactEmails: [contactEmail]
+      }
+    }
+  }
+}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -16,8 +16,14 @@ param deployIdentityName string = 'adorio-github-deploy-identity'
 @description('GitHub repo in "owner/repo" form, used to scope the OIDC federated credential')
 param githubRepo string = 'Mykal-Steele/Adorio'
 
-@description('Bootstrap image used on first deploy, before CI has pushed a real image')
-param bootstrapImage string = 'mcr.microsoft.com/k8se/quickstart:latest'
+// No default on purpose. This template gets re-applied for infra changes unrelated to
+// app code (RBAC, scaling, etc.) — CI owns image updates via `az containerapp update`
+// and never re-runs this template. If this had a default, re-applying the template for
+// an infra tweak would silently reset the running app back to that default and cut
+// traffic over to it, which is exactly what happened once already. Always pass the
+// currently-running image explicitly: `--parameters containerImage=<current image>`.
+@description('Image the container app should run — always pass the current running image explicitly, no default')
+param containerImage string
 
 @secure()
 param mongoUri string
@@ -139,7 +145,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
       containers: [
         {
           name: containerAppName
-          image: bootstrapImage
+          image: containerImage
           resources: {
             cpu: json('1.0')
             memory: '2Gi'
@@ -209,6 +215,20 @@ resource acrPushForDeployIdentity 'Microsoft.Authorization/roleAssignments@2022-
   scope: registry
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8311e382-0749-4cb8-b61a-304f252e45ec')
+    principalId: deployIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// `az acr build` needs this in addition to AcrPush — it's an ARM-level orchestration
+// role (uploading build context, queuing the run), not a data-plane push/pull action.
+// AcrPush alone gets "resource could not be found" / "AuthorizationFailed" on
+// listBuildSourceUploadUrl, confirmed the hard way against the real registry.
+resource acrTasksContributorForDeployIdentity 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(registry.id, deployIdentity.id, 'ContainerRegistryTasksContributor')
+  scope: registry
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fb382eab-e894-4461-af04-94435c366c3f')
     principalId: deployIdentity.properties.principalId
     principalType: 'ServicePrincipal'
   }


### PR DESCRIPTION
## Summary
Two fixes and one addition, all triggered by cleaning up after the first real production deploy (PR 27):

**1. ACR build permissions were incomplete.** The first live deploy failed twice:
- First: `AcrPush` alone made `az acr build` unable to even resolve the registry ("could not be found") — AcrPush's actual permissions are just `registries/pull/read` and `registries/push/write`, no general ARM-level read.
- Second, after granting `Reader`: hit `AuthorizationFailed` on `Microsoft.ContainerRegistry/registries/listBuildSourceUploadUrl/action` — `az acr build` orchestrates the build via ACR Tasks, which needs the `Container Registry Tasks Contributor` role, not just data-plane push/pull or generic read.
- Fixed by granting `Container Registry Tasks Contributor` to the deploy identity (`infra/main.bicep`). Confirmed against the real registry by re-running the actual GitHub Actions job twice, not just from docs.

**2. The container image had a dangerous default.** While testing the fix above, re-applying the Bicep template (needed to add the role assignment) silently reset the running container app back to its bootstrap placeholder image and shifted 100% traffic to it, because `image` had a default value. Caught this via the live health check, restored the real revision with `az containerapp update --image <known-good-sha>`, and removed the default entirely — `containerImage` is now a required parameter with no fallback, so any future infra-only re-apply *must* explicitly state the current image instead of silently reverting it.

**3. Added a subscription-level budget** (`infra/budget.bicep`) — $150/mo matching the recurring credit, with email alerts at 50/80/100% actual spend and 100% forecasted. This is alert-only; it doesn't cap or throttle spend automatically (that needs a separate action-group/automation setup, which felt like a bigger, riskier addition than what was asked for here).

## What was live-patched directly (not in this diff, already applied to the real subscription)
- Removed two ad-hoc `az role assignment create` grants made while diagnosing, once the equivalent grant was properly declared in Bicep and re-applied — no orphaned manual permissions left behind.
- Budget deployed for real via `az deployment sub create`.
- Site was briefly down (empty revision list, 404) after a bad manual `az containerapp revision deactivate` call while cleaning up the wrong revision — recovered immediately by forcing a fresh revision with the known-good image. Site is confirmed healthy now.

## Test plan
- [x] `az bicep build` on both files — clean
- [x] `az deployment sub what-if` for the budget — validated before applying
- [x] Confirmed live: `curl .../api/health` returns 200 with real app data, correct revision Active/Healthy/Running with the right image
- [x] `npm run format:check` / `npm run lint` — clean (infra files aren't in scope for either)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable monthly Azure budget monitoring.
  * Added actual-spend alerts at 50%, 80%, and 100% of the budget, plus forecasted-spend alerts.
  * Deployment now requires an explicit container image.
  * Improved deployment permissions for container image build and publishing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->