### PR TITLE
docs(claude): update request flow now that the custom domain is live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ npm run test:prod        # integration tests against prod containers
 ### Request Flow (Production)
 
 ```
-Browser → Azure Container Apps ingress (managed TLS, Envoy)
+Browser → Cloudflare CDN (SSL mode: Full strict) → Azure Container Apps ingress (managed TLS, Envoy)
   └─ Container App `adorio` (single active revision, minReplicas 1, autoscale to 3)
        └─ Nginx (plain HTTP :8080 — Container Apps terminates TLS at the platform edge)
             ├─ /api/*          → localhost:3000 (Express backend)
@@ -78,7 +78,7 @@ Browser → Azure Container Apps ingress (managed TLS, Envoy)
 
 The backend, Next.js standalone server, and Nginx all run in the same Docker container, same as before the Azure migration. `nginx.production.conf` no longer terminates TLS itself (dropped in the migration — Container Apps' ingress does that now with a free managed certificate). `nginx.production.conf` / `nginx.development.conf` are still selected at image build time via the `$ENV` build arg.
 
-**Custom domain note**: `adorio.space` → Cloudflare cutover hasn't happened yet — the site is currently only reachable at its Azure-issued FQDN (`adorio.<env-id>.southeastasia.azurecontainerapps.io`). Binding the custom domain + managed cert to the Container App, then repointing Cloudflare DNS, is still on the migration to-do list.
+**Custom domain**: `adorio.space` and `www.adorio.space` are both bound to the Container App with Azure-managed certificates (`SniEnabled`). Root domain uses an A record to the Container Apps environment's static IP + `HTTP` validation (apex domains can't use CNAME/managed-cert validation the way subdomains can); `www` uses a CNAME straight to the container app's default FQDN + `CNAME` validation. Both records are proxied through Cloudflare (SSL mode `Full (strict)`, safe now that the origin presents a real trusted cert instead of a manually mounted one).
 
 ### Hosting
 


### PR DESCRIPTION
## Summary
Follow-up to the custom domain cutover (done directly against the live subscription/Cloudflare zone, not through a PR — there's no code diff for DNS/cert binding). `CLAUDE.md` said the cutover "hasn't happened yet," which became stale the moment it actually happened. Updates the Request Flow diagram and adds a short note on how the two domains are actually validated:

- `adorio.space` (apex) — A record to the Container Apps environment's static IP, `HTTP` validation (apex domains can't use CNAME/managed-cert validation)
- `www.adorio.space` — CNAME straight to the container app's FQDN, `CNAME` validation
- Both proxied through Cloudflare, SSL mode bumped to `Full (strict)` now that the origin has a real Azure-issued cert

Both confirmed live: `curl https://adorio.space/api/health` and `https://www.adorio.space/api/health` both return real, healthy responses through the full Cloudflare → Azure chain.

## Test plan
- [x] `curl https://adorio.space/api/health` — 200, healthy
- [x] `curl https://www.adorio.space/api/health` — 200, healthy
- [x] DNS resolution confirms Cloudflare proxy is active (root A record resolves to Cloudflare edge IPs, not Azure directly)
- [x] `npm run format:check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated production deployment documentation to reflect Cloudflare CDN and SSL routing before Azure Container Apps ingress.
  * Documented domain certificate management, DNS validation, and strict SSL configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->